### PR TITLE
エラー画面を調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'sass-rails', '~> 5.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'jquery-rails'
-# gem 'compass-rails', '~> 2.0.5'
 gem 'font-awesome-rails'
 gem 'rails-i18n'
 gem 'slim-rails'
@@ -30,7 +29,7 @@ gem 'rails_admin-i18n'
 
 # CSS
 gem 'bulma-rails', '~> 0.3.0'
-gem 'normalize-rails'
+# gem 'compass-rails'
 
 # authentication
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     bulma-rails (0.3.0)
       sass (~> 3.2)
     byebug (9.0.6)
+    chunky_png (1.3.8)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -73,6 +74,22 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
+    compass (1.0.3)
+      chunky_png (~> 1.2)
+      compass-core (~> 1.0.2)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.3)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    compass-rails (3.0.2)
+      compass (~> 1.0.0)
+      sass-rails (< 5.1)
+      sprockets (< 4.0)
     concurrent-ruby (1.0.4)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
@@ -332,6 +349,7 @@ DEPENDENCIES
   bulma-rails (~> 0.3.0)
   byebug
   coffee-rails (~> 4.2)
+  compass-rails
   database_cleaner
   devise
   devise-i18n

--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -8,6 +8,5 @@ $warning: #e4a020
 // $text: $grey-dark
 
 @import "bulma"
-@import "normalize-rails"
 @import "font-awesome"
 @import "partials/*"

--- a/app/assets/stylesheets/partials/form.sass
+++ b/app/assets/stylesheets/partials/form.sass
@@ -1,2 +1,6 @@
 label.is-danger
   color: $danger
+
+p.control
+  span.help:not(:first-of-type)
+    margin-top: 0

--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -4,39 +4,41 @@
 .containar
   .columns
     .column.is-half.is-offset-one-quarter
-      - if @admin.errors.any?
-        article.message.is-danger
-          .message-header
-            p
-              = @admin.errors.count
-              | 件のエラーがあります。
-          .message-body
-            ul
-              - @admin.errors.full_messages.each do |msg|
-                li
-                  = msg
+      = render partial: "shared/error_notification", locals: { model: @admin }
+
       h1.title
         = title
       h2.subtitle.is-6
         | アカウント情報の編集を行います。
+
       = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
         = f.label :name, class: :label
         p.control
           = f.text_field :name, class: :input, autofocus: true
+          = render partial: "shared/error_message", locals: { model: @admin, attribute: :name }
+
         = f.label :email, class: :label
         p.control
           = f.email_field :email, class: :input, autofocus: true
+          = render partial: "shared/error_message", locals: { model: @admin, attribute: :email }
+
         = f.label :password, class: :label
         p.control
           = f.password_field :password, class: :input, autocomplete: "off"
           span.help
             | 空欄にした場合は変更されません。
+          = render partial: "shared/error_message", locals: { model: @admin, attribute: :password }
+
         = f.label :password_confirmation, class: :label
         p.control
           = f.password_field :password_confirmation, class: :input, autocomplete: "off"
+          = render partial: "shared/error_message", locals: { model: @admin, attribute: :password_confirmation }
+
         = f.label :current_password, class: :label
         div.control
           = f.password_field :current_password, class: :input, autocomplete: "off"
+          = render partial: "shared/error_message", locals: { model: @admin, attribute: :current_password }
+
         p.control
           = f.submit "更新する", class: "button is-primary"
       / p.control

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,7 +1,7 @@
 - content_for :title, t(".title")
 
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  section.hero.is-primary.is-fullheight
+  section.hero.is-primary.is-fullheight.is-flex-mobile
     .hero-body
       .container
         .columns

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -32,4 +32,5 @@
             / p.has-text-centered
             /   = render "devise/shared/links"
             p.has-text-centered
-              small Copyright &copy; 2017 comorebi notes All Rights Reserved.
+              small
+                | Copyright &copy; 2017 comorebi notes All Rights Reserved.

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -11,7 +11,7 @@ html
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
   body
-    = render "admins/header"
+    = render "shared/header"
     section.section
       .container
         - if notice
@@ -20,5 +20,5 @@ html
         - if alert
           p.notification.is-danger
             = alert
-
         = yield
+    = render "shared/footer"

--- a/app/views/shared/_error_message.html.slim
+++ b/app/views/shared/_error_message.html.slim
@@ -1,0 +1,3 @@
+- model.errors.full_messages_for(attribute).each do |msg|
+  span.help.is-danger
+    = msg

--- a/app/views/shared/_error_notification.html.slim
+++ b/app/views/shared/_error_notification.html.slim
@@ -1,0 +1,5 @@
+- if model.errors.any?
+  .notification.is-danger
+    p
+      = model.errors.count
+      | 件のエラーがあります。

--- a/app/views/shared/_footer.html.slim
+++ b/app/views/shared/_footer.html.slim
@@ -1,0 +1,11 @@
+footer.footer
+  .container
+    .content.has-text-centered
+      p
+        small
+          | Copyright &copy; 2017 comorebi notes All Rights Reserved.
+      p
+        a.icon href="https://github.com/kero-uzura/comorebi"
+          = fa_icon "github"
+        a.icon href="https://twitter.com/kero_BIRUGE" style="margin-left: .3em"
+          = fa_icon "twitter"

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -10,4 +10,4 @@ section.hero.is-primary.is-medium
             = "@#{current_admin.name}"
           .nav-item
             = link_to destroy_admin_session_path, class: "button is-primary is-inverted", method: :delete do
-              span ログアウト
+              span logout

--- a/config/locales/defaults/ja.yml
+++ b/config/locales/defaults/ja.yml
@@ -5,8 +5,8 @@ ja:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
-          has_one: "%{record}が存在しているので削除できません"
-          has_many: "%{record}が存在しているので削除できません"
+          has_one: "%{record}が存在しているので削除できません。"
+          has_many: "%{record}が存在しているので削除できません。"
   date:
     abbr_day_names:
     - 日
@@ -106,35 +106,35 @@ ja:
   errors:
     format: "%{attribute}%{message}"
     messages:
-      accepted: を受諾してください
-      blank: を入力してください
-      present: は入力しないでください
-      confirmation: と%{attribute}の入力が一致しません
-      empty: を入力してください
-      equal_to: は%{count}にしてください
-      even: は偶数にしてください
-      exclusion: は予約されています
-      greater_than: は%{count}より大きい値にしてください
-      greater_than_or_equal_to: は%{count}以上の値にしてください
-      inclusion: は一覧にありません
-      invalid: は不正な値です
-      less_than: は%{count}より小さい値にしてください
-      less_than_or_equal_to: は%{count}以下の値にしてください
+      accepted: を受諾してください。
+      blank: を入力してください。
+      present: は入力しないでください。
+      confirmation: と%{attribute}の入力が一致しません。
+      empty: を入力してください。
+      equal_to: は%{count}にしてください。
+      even: は偶数にしてください。
+      exclusion: は予約されています。
+      greater_than: は%{count}より大きい値にしてください。
+      greater_than_or_equal_to: は%{count}以上の値にしてください。
+      inclusion: は一覧にありません。
+      invalid: は不正な値です。
+      less_than: は%{count}より小さい値にしてください。
+      less_than_or_equal_to: は%{count}以下の値にしてください。
       model_invalid: "バリデーションに失敗しました: %{errors}"
-      not_a_number: は数値で入力してください
-      not_an_integer: は整数で入力してください
-      odd: は奇数にしてください
-      required: を入力してください
-      taken: はすでに存在します
-      too_long: は%{count}文字以内で入力してください
-      too_short: は%{count}文字以上で入力してください
-      wrong_length: は%{count}文字で入力してください
-      other_than: は%{count}以外の値にしてください
+      not_a_number: は数値で入力してください。
+      not_an_integer: は整数で入力してください。
+      odd: は奇数にしてください。
+      required: を入力してください。
+      taken: はすでに存在します。
+      too_long: は%{count}文字以内で入力してください。
+      too_short: は%{count}文字以上で入力してください。
+      wrong_length: は%{count}文字で入力してください。
+      other_than: は%{count}以外の値にしてください。
     template:
-      body: 次の項目を確認してください
+      body: 次の項目を確認してください。
       header:
-        one: "%{model}にエラーが発生しました"
-        other: "%{model}に%{count}個のエラーが発生しました"
+        one: "%{model}にエラーが発生しました。"
+        other: "%{model}に%{count}個のエラーが発生しました。"
   helpers:
     select:
       prompt: 選択してください


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/16236972/22114799/11594bd4-deae-11e6-845c-db9ee0c8c10d.png)
- 各フォームにエラーを出力するように変更
- エラーメッセージに句点 `。` を追加
- ついでに footer を追加
- normalize css が悪影響を及ぼしていたため削除